### PR TITLE
fix(skill): add YAML frontmatter so `skills` CLI can detect SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,9 @@
-# wx-cli
+---
+name: wx-cli
+description: "wx-cli — 从本地微信数据库查询聊天记录、联系人、会话、收藏等。用户提到微信聊天记录、联系人、消息历史、群成员、收藏内容时，使用此 skill 安装并调用 wx-cli。"
+---
 
-> description: "wx-cli — 从本地微信数据库查询聊天记录、联系人、会话、收藏等。用户提到微信聊天记录、联系人、消息历史、群成员、收藏内容时，使用此 skill 安装并调用 wx-cli。"
+# wx-cli
 
 ## Triggers
 


### PR DESCRIPTION
## Summary

`npx skills add jackwener/wx-cli -g` currently fails with:

```
No valid skills found. Skills require a SKILL.md with name and description.
```

The [`skills` CLI](https://github.com/openclaw/skills) parses **YAML frontmatter** at the top of `SKILL.md` to discover the skill's `name` and `description`. The current file declares the description as a Markdown blockquote (`> description: "..."`), which the parser ignores — so the skill is never registered.

This PR converts those two lines into a proper frontmatter block. No content is removed; the `# wx-cli` heading and description text are preserved exactly.

## Diff

```diff
+---
+name: wx-cli
+description: "wx-cli — 从本地微信数据库查询聊天记录、联系人、会话、收藏等。..."
+---
+
 # wx-cli

-> description: "wx-cli — 从本地微信数据库..."
```

## Test plan

- [x] `npx skills add . -l` (in repo root) reports `Found 1 skill: wx-cli` — previously reported `No skills found`.
- [x] Markdown rendering on GitHub still shows the heading and description.
- [ ] Maintainer can confirm `npx skills add jackwener/wx-cli -g -y` now installs end-to-end.