### PR TITLE
fix(init): make `sudo wx init` work end-to-end + bind --version to crate version

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -44,6 +44,13 @@ pub fn cmd_init(force: bool) -> Result<()> {
     let entries = scanner::scan_keys(&db_dir)?;
 
     // Step 3: 保存 all_keys.json
+    // 先确保父目录存在（如 ~/.wx-cli/），避免首次运行时写入失败。
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("创建目录失败: {}", parent.display()))?;
+        chown_to_sudo_user(parent);
+    }
+
     let keys_file_path = config_path.parent()
         .unwrap_or(std::path::Path::new("."))
         .join("all_keys.json");
@@ -55,7 +62,8 @@ pub fn cmd_init(force: bool) -> Result<()> {
         }));
     }
     std::fs::write(&keys_file_path, serde_json::to_string_pretty(&keys_json)?)
-        .context("写入 all_keys.json 失败")?;
+        .with_context(|| format!("写入 all_keys.json 失败: {}", keys_file_path.display()))?;
+    chown_to_sudo_user(&keys_file_path);
     println!("成功提取 {} 个数据库密钥", entries.len());
     println!("密钥已保存: {}", keys_file_path.display());
 
@@ -75,18 +83,31 @@ pub fn cmd_init(force: bool) -> Result<()> {
     cfg.entry("keys_file".into()).or_insert_with(|| json!("all_keys.json"));
     cfg.entry("decrypted_dir".into()).or_insert_with(|| json!("decrypted"));
 
-    // 确保父目录存在（如 ~/.wx-cli/）
-    if let Some(parent) = config_path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("创建目录失败: {}", parent.display()))?;
-    }
     std::fs::write(&config_path, serde_json::to_string_pretty(&cfg)?)
-        .context("写入 config.json 失败")?;
+        .with_context(|| format!("写入 config.json 失败: {}", config_path.display()))?;
+    chown_to_sudo_user(&config_path);
     println!("配置已保存: {}", config_path.display());
     println!("初始化完成，可以使用 wx sessions / wx history 等命令了");
 
     Ok(())
 }
+
+/// 当通过 sudo 调用时，把刚写入的文件/目录归还给真实用户，否则后续以
+/// 普通用户身份运行的 daemon / CLI 无法读写它们。
+#[cfg(unix)]
+fn chown_to_sudo_user(path: &std::path::Path) {
+    let (Some(uid), Some(gid)) = (
+        std::env::var("SUDO_UID").ok().and_then(|s| s.parse::<u32>().ok()),
+        std::env::var("SUDO_GID").ok().and_then(|s| s.parse::<u32>().ok()),
+    ) else {
+        return;
+    };
+    // 静默忽略 chown 失败：路径可能在 root 拥有的卷上，或本身已属于该用户。
+    let _ = std::os::unix::fs::chown(path, Some(uid), Some(gid));
+}
+
+#[cfg(not(unix))]
+fn chown_to_sudo_user(_path: &std::path::Path) {}
 
 fn find_or_create_config_path() -> std::path::PathBuf {
     // 如果当前工作目录或可执行文件目录已有 config.json，沿用它（支持便携模式）

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -18,7 +18,7 @@ use clap::{Parser, Subcommand};
 
 /// wx — 微信本地数据 CLI
 #[derive(Parser)]
-#[command(name = "wx", version = "0.1.0", about = "wx — 微信本地数据 CLI")]
+#[command(name = "wx", version = env!("CARGO_PKG_VERSION"), about = "wx — 微信本地数据 CLI")]
 pub struct Cli {
     #[command(subcommand)]
     command: Commands,

--- a/src/config.rs
+++ b/src/config.rs
@@ -86,8 +86,30 @@ fn find_config_file() -> Result<PathBuf> {
     Ok(PathBuf::from("config.json"))
 }
 
-pub fn cli_dir() -> PathBuf {
+/// 真实用户的 home 目录。
+///
+/// 当通过 sudo 调用时，`dirs::home_dir()` 会返回 `/var/root`（或 `/root`），
+/// 导致 `~/.wx-cli/` 落在 root 名下，daemon 后续以普通用户身份启动时无法读写。
+/// 这里优先使用 sudo 注入的 `SUDO_USER` 反查真实用户的 home。
+pub fn effective_home() -> Option<PathBuf> {
+    if let Ok(sudo_user) = std::env::var("SUDO_USER") {
+        if !sudo_user.is_empty() && sudo_user != "root" {
+            #[cfg(target_os = "macos")]
+            let candidate = PathBuf::from("/Users").join(&sudo_user);
+            #[cfg(target_os = "linux")]
+            let candidate = PathBuf::from("/home").join(&sudo_user);
+            #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+            let candidate = dirs::home_dir().unwrap_or_default();
+            if candidate.is_dir() {
+                return Some(candidate);
+            }
+        }
+    }
     dirs::home_dir()
+}
+
+pub fn cli_dir() -> PathBuf {
+    effective_home()
         .unwrap_or_else(|| PathBuf::from("/tmp"))
         .join(".wx-cli")
 }


### PR DESCRIPTION
Three small fixes that surfaced during a fresh install on macOS 26 + WeChat 4.1.52.

## 1. `wx --version` reports `0.1.0` regardless of the published crate

`src/cli/mod.rs:21` hard-codes the version string in the clap attribute. Even after `Cargo.toml` was bumped to `0.1.5` the binary still prints `wx 0.1.0`, which makes triage much harder ("user reports a 0.1.0 bug" — but they actually have 0.1.5).

Fix: use `env!(\"CARGO_PKG_VERSION\")` so the CLI always tracks `Cargo.toml`.

## 2. `config::cli_dir()` resolves to `/var/root/.wx-cli/` under sudo

`init` is documented to require `sudo` (memory scan needs `task_for_pid`). But `dirs::home_dir()` honors the effective uid, so under sudo it returns `/var/root` (or `/root` on Linux). All the artifacts — `all_keys.json`, `config.json`, `daemon.sock`, `daemon.pid` — then live in root's home and the subsequent (non-sudo) `wx sessions` / daemon launch can't read them.

Note that `config::detect_db_dir_impl` already special-cases `\$SUDO_USER` — this PR generalizes that into `effective_home()` and routes `cli_dir()` through it. (The detect functions still use their inline logic; happy to also dedupe in a follow-up if you prefer.)

## 3. `cmd_init` writes `all_keys.json` before `create_dir_all`

On a fresh machine `~/.wx-cli/` doesn't exist yet. The current code creates it only at step 4 (right before writing `config.json`), but the step-3 write to `all_keys.json` happens earlier and aborts with `\"写入 all_keys.json 失败\"`.

Fix: create the parent dir first, then write keys, then write config. Each `write` is now annotated with the failing path for easier diagnosis. Also chown every created file/directory to `\$SUDO_UID:\$SUDO_GID` so the daemon (which runs as the real user) can read them afterwards — without this you get \"works first time, broken on the second invocation\" symptoms.

## Repro

Before:

```console
\$ rm -rf ~/.wx-cli
\$ sudo wx init
检测微信数据目录...
找到数据目录: /Users/leo/Library/.../db_storage
扫描加密密钥（需要 root 权限）...
错误: 写入 all_keys.json 失败
```

After:

```console
\$ rm -rf ~/.wx-cli && sudo wx init
密钥已保存: /Users/leo/.wx-cli/all_keys.json
配置已保存: /Users/leo/.wx-cli/config.json
\$ stat -f '%Su' ~/.wx-cli/all_keys.json
leo
\$ wx --version
wx 0.1.5
```

## Test plan

- [x] `cargo check` clean
- [x] `cargo build --release && ./target/release/wx --version` → `wx 0.1.5`
- [x] Verified end-to-end on macOS 26.4 / WeChat 4.1.52: `sudo wx init` now creates `~/.wx-cli/{all_keys,config}.json` owned by the invoking user
- [ ] Linux verification (logic mirrors macOS via `\$SUDO_USER` → `/home/<u>`, but I haven't booted a Linux box)

## Out of scope (separate issue worth opening)

On WeChat 4.1.52 the scanner now reports `匹配到 0/N 个密钥` — the keys this PR successfully writes are an empty set. That's a separate problem in `scanner::scan_keys` (likely a key-derivation / memory-layout change in 4.1.x); happy to file a tracking issue with details if useful.