### PR TITLE
docs(readme): 说明如何获取超过 500 条消息

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,14 @@ wx unread                                        # 有未读消息的会话
 wx unread --filter private,group                 # 只看真人未读（过滤公众号/折叠入口）
 wx new-messages                                  # 上次检查后的新消息（增量）
 wx history "张三"                                # 最近 50 条记录
+wx history "张三" -n 2000                        # 拉更多历史消息
 wx history "AI群" --since 2026-04-01 --until 2026-04-15
 wx search "关键词"                               # 全库搜索
+wx search "关键词" -n 500                        # 放宽搜索结果条数
 wx search "会议" --in "工作群" --since 2026-01-01
 ```
+
+`history` / `search` / `export` 都支持 `-n` / `--limit` 指定条数。默认值只是为了避免一次性输出过多消息，不是硬上限。
 
 会话/消息输出里都带 `chat_type` 字段，取值为 `private` / `group` / `official_account` / `folded`。`official_account` 涵盖公众号、订阅号、服务号及 `mphelper` / `qqsafe` 等系统通知；`folded` 对应微信里的"订阅号折叠"和"折叠群聊"两个聚合入口。
 
@@ -174,6 +178,7 @@ wx stats "AI群" --since 2026-01-01   # 指定时间范围
 
 ```bash
 wx export "张三" --format markdown -o chat.md
+wx export "张三" -n 2000 --format markdown -o chat.md
 wx export "AI群" --since 2026-01-01 --format json
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -115,12 +115,16 @@ wx new-messages --json          # JSON 输出，适合 agent 解析
 
 # 聊天记录（支持昵称/备注名）
 wx history "张三"
+wx history "张三" -n 2000
 wx history "AI群" --since 2026-04-01 --until 2026-04-15 -n 100
 
 # 全库搜索
 wx search "关键词"
+wx search "关键词" -n 500
 wx search "会议" --in "工作群" --since 2026-01-01
 ```
+
+`history` / `search` / `export` 都支持 `-n` / `--limit` 指定返回条数。默认值只是为了避免一次输出过多，不是硬上限。
 
 `sessions` / `unread` / `history` / `new-messages` / `stats` 的输出都带 `chat_type` 字段，agent 可据此分流：
 
@@ -166,6 +170,7 @@ wx stats "AI群" --since 2026-01-01
 ```bash
 # 导出为 Markdown（默认）
 wx export "张三" --format markdown -o chat.md
+wx export "张三" -n 2000 --format markdown -o chat.md
 
 # 导出为 JSON
 wx export "AI群" --since 2026-01-01 --format json -o chat.json
@@ -216,3 +221,5 @@ CHAT 参数支持昵称、备注名、微信 ID，模糊匹配。不确定准确
 **daemon 无响应**：`wx daemon stop` 后重新调用任意命令自动重启。
 
 **找不到聊天**：用 `wx contacts --query` 确认昵称/备注名，或用微信 ID 直接查询。
+
+**为什么只能获取 500 条消息？**：这是默认输出条数，不是硬限制。显式传 `-n` 即可，例如 `wx history "张三" -n 2000` 或 `wx export "张三" -n 2000 -o chat.md`。


### PR DESCRIPTION
Closes #12

## 现象 / Symptom
用户阅读示例时，容易误以为 `wx` 最多只能返回 500 条消息，因为文档没有说明 `-n/--limit` 可以覆盖默认值。

## 根因 / Root cause
README 和 SKILL 里的示例只展示了默认行为，但没有明确写出 `history`、`search`、`export` 都支持通过 `-n/--limit` 请求更多结果。

## 修法 / Fix
在 README 和 SKILL 中补充 `-n/--limit` 的说明，增加更大条数的 `history` / `search` / `export` 示例，并加一条简短 FAQ，解释“500 条”只是默认值，不是硬上限。

## Test plan
- [x] 纯文档改动；无需 cargo 验证。
- [x] 通过 `src/cli/history.rs:19` 确认 `history` 会透传 `limit`。
- [x] 通过 `src/cli/mod.rs:76` 和 `src/cli/mod.rs:115` 确认 `search` 与 `export` 的默认条数定义。