### PR TITLE
feat: expose url field for link/appmsg messages

### DIFF
--- a/src/daemon/query.rs
+++ b/src/daemon/query.rs
@@ -549,15 +549,20 @@ fn query_messages(
         let content = decompress_message(&content_bytes, ct);
         let sender = sender_label(real_sender_id, &content, is_group, chat_username, &id2u, names_map, group_nicknames);
         let text = fmt_content(local_id, local_type, &content, is_group);
+        let url = appmsg_url_for_message(local_type, &content);
 
-        result.push(json!({
+        let mut msg = json!({
             "timestamp": ts,
             "time": fmt_time(ts, "%Y-%m-%d %H:%M"),
             "sender": sender,
             "content": text,
             "type": fmt_type(local_type),
             "local_id": local_id,
-        }));
+        });
+        if let Some(u) = url {
+            msg["url"] = serde_json::Value::String(u);
+        }
+        result.push(msg);
     }
     Ok(result)
 }
@@ -636,15 +641,20 @@ fn search_in_table(
         if search_decoded_content && !matches_search_text(&content, &text, keyword, &keyword_lower) {
             continue;
         }
+        let url = appmsg_url_for_message(local_type, &content);
 
-        result.push(json!({
+        let mut msg = json!({
             "timestamp": ts,
             "time": fmt_time(ts, "%Y-%m-%d %H:%M"),
             "chat": "",
             "sender": sender,
             "content": text,
             "type": fmt_type(local_type),
-        }));
+        });
+        if let Some(u) = url {
+            msg["url"] = serde_json::Value::String(u);
+        }
+        result.push(msg);
         if search_decoded_content && result.len() >= limit {
             break;
         }
@@ -1271,6 +1281,25 @@ fn extract_xml_text(xml: &str, tag: &str) -> Option<String> {
     let content_start = start + open.len();
     let end = xml[content_start..].find(&close)?;
     Some(xml[content_start..content_start + end].trim().to_string())
+}
+
+/// 从 appmsg XML 中提取链接 URL（优先取 <url>，fallback 到 <url1>）
+fn extract_appmsg_url(text: &str) -> Option<String> {
+    // 群消息前缀 "wxid_xxx:\n" 需先剥离
+    let xml = if text.contains(":\n") {
+        text.splitn(2, ":\n").nth(1).unwrap_or(text)
+    } else {
+        text
+    };
+    if !xml.contains("<appmsg") {
+        return None;
+    }
+    let url = extract_xml_text(xml, "url")
+        .or_else(|| extract_xml_text(xml, "url1"))?;
+    if url.is_empty() || !url.starts_with("http") {
+        return None;
+    }
+    Some(url)
 }
 
 fn extract_xml_attr(xml: &str, tag: &str, attr: &str) -> Option<String> {

--- a/src/daemon/query.rs
+++ b/src/daemon/query.rs
@@ -1283,20 +1283,32 @@ fn extract_xml_text(xml: &str, tag: &str) -> Option<String> {
     Some(xml[content_start..content_start + end].trim().to_string())
 }
 
+fn appmsg_url_for_message(local_type: i64, content: &str) -> Option<String> {
+    if (local_type as u64 & 0xFFFFFFFF) != 49 {
+        return None;
+    }
+    extract_appmsg_url(content)
+}
+
+fn strip_xml_cdata(s: &str) -> &str {
+    s.strip_prefix("<![CDATA[")
+        .and_then(|inner| inner.strip_suffix("]]>"))
+        .unwrap_or(s)
+}
+
 /// 从 appmsg XML 中提取链接 URL（优先取 <url>，fallback 到 <url1>）
 fn extract_appmsg_url(text: &str) -> Option<String> {
-    // 群消息前缀 "wxid_xxx:\n" 需先剥离
-    let xml = if text.contains(":\n") {
-        text.splitn(2, ":\n").nth(1).unwrap_or(text)
-    } else {
-        text
-    };
+    let xml = strip_group_prefix(text);
     if !xml.contains("<appmsg") {
         return None;
     }
-    let url = extract_xml_text(xml, "url")
-        .or_else(|| extract_xml_text(xml, "url1"))?;
-    if url.is_empty() || !url.starts_with("http") {
+    if extract_xml_text(&xml, "type").as_deref() == Some("57") {
+        return None;
+    }
+    let url = extract_xml_text(&xml, "url")
+        .or_else(|| extract_xml_text(&xml, "url1"))
+        .map(|s| unescape_html(strip_xml_cdata(&s)))?;
+    if url.is_empty() || !(url.starts_with("http://") || url.starts_with("https://")) {
         return None;
     }
     Some(url)
@@ -1935,7 +1947,8 @@ pub async fn q_new_messages(
                     let content = decompress_message(&content_bytes, ct);
                     let sender = sender_label(real_sender_id, &content, is_group, &uname2, &id2u, &names_map, &group_nicknames2);
                     let text = fmt_content(local_id, local_type, &content, is_group);
-                    result.push(json!({
+                    let url = appmsg_url_for_message(local_type, &content);
+                    let mut msg = json!({
                         "chat": display2,
                         "username": uname2,
                         "is_group": is_group,
@@ -1945,7 +1958,11 @@ pub async fn q_new_messages(
                         "sender": sender,
                         "content": text,
                         "type": fmt_type(local_type),
-                    }));
+                    });
+                    if let Some(u) = url {
+                        msg["url"] = serde_json::Value::String(u);
+                    }
+                    result.push(msg);
                 }
                 Ok::<_, anyhow::Error>(result)
             }).await {
@@ -2953,6 +2970,71 @@ mod sns_tests {
         assert_eq!(escape_like_pattern("hello world"), "hello world");
         assert_eq!(escape_like_pattern("中文关键词"), "中文关键词");
         assert_eq!(escape_like_pattern(""), "");
+    }
+
+    #[test]
+    fn extract_appmsg_url_unescapes_html_entities() {
+        let xml = concat!(
+            "<appmsg>",
+            "<type>5</type>",
+            "<url>https://mp.weixin.qq.com/s?__biz=MzI4&amp;mid=2247&amp;idx=1</url>",
+            "</appmsg>"
+        );
+        assert_eq!(
+            extract_appmsg_url(xml).as_deref(),
+            Some("https://mp.weixin.qq.com/s?__biz=MzI4&mid=2247&idx=1")
+        );
+    }
+
+    #[test]
+    fn extract_appmsg_url_strips_group_prefix_and_cdata() {
+        let xml = concat!(
+            "wxid_sender:\n",
+            "<appmsg>",
+            "<type>5</type>",
+            "<url><![CDATA[https://example.com/x?a=1&b=2]]></url>",
+            "</appmsg>"
+        );
+        assert_eq!(
+            extract_appmsg_url(xml).as_deref(),
+            Some("https://example.com/x?a=1&b=2")
+        );
+    }
+
+    #[test]
+    fn extract_appmsg_url_falls_back_to_url1() {
+        let xml = concat!(
+            "<appmsg>",
+            "<type>5</type>",
+            "<url1>https://example.com/fallback</url1>",
+            "</appmsg>"
+        );
+        assert_eq!(
+            extract_appmsg_url(xml).as_deref(),
+            Some("https://example.com/fallback")
+        );
+    }
+
+    #[test]
+    fn extract_appmsg_url_ignores_non_http_values() {
+        let xml = concat!(
+            "<appmsg>",
+            "<type>5</type>",
+            "<url>weixin://bizmsgmenu?msgmenucontent=foo</url>",
+            "</appmsg>"
+        );
+        assert_eq!(extract_appmsg_url(xml), None);
+    }
+
+    #[test]
+    fn extract_appmsg_url_ignores_refermsg() {
+        let xml = concat!(
+            "<appmsg>",
+            "<type>57</type>",
+            "<url>https://example.com/nested</url>",
+            "</appmsg>"
+        );
+        assert_eq!(extract_appmsg_url(xml), None);
     }
 
     fn media_object(value: &Value) -> &serde_json::Map<String, Value> {


### PR DESCRIPTION
## 问题

`wx history` / `wx search` 输出的链接消息（`local_type=49`）只有标题，没有 URL，导致无法直接跳转原文。

## 方案

在 `src/daemon/query.rs` 中新增 `extract_appmsg_url()` 函数，解析 appmsg XML 中的 `<url>` 字段（fallback 到 `<url1>`），并在 `query_messages` 和 `search_in_table` 的输出 JSON 中附加 `url` 字段。

- 只对 `local_type & 0xFFFFFFFF == 49` 的消息提取
- URL 为空或非 http 时省略该字段（不输出 null）
- 不改变现有函数签名，改动最小

## 输出变化

修复前：
```yaml
content: "[链接] 我把微信 cli 开源了！"
type: 链接/文件
```

修复后：
```yaml
content: "[链接] 我把微信 cli 开源了！"
type: 链接/文件
url: "https://mp.weixin.qq.com/s?__biz=..."
```