### PR TITLE
feat(appmsg): 支持合并聊天记录与文件消息解析

### DIFF
--- a/src/daemon/query.rs
+++ b/src/daemon/query.rs
@@ -1202,8 +1202,25 @@ fn parse_sysmsg(xml: &str) -> Option<String> {
 }
 
 fn parse_appmsg(text: &str) -> Option<String> {
-    // 简单 XML 解析，避免引入重量级 XML 库（或直接用 minidom）
-    // 这里用基本字符串搜索实现
+    if let Some(parsed) = parse_appmsg_dom(text) {
+        return Some(parsed);
+    }
+    parse_appmsg_legacy(text)
+}
+
+fn parse_appmsg_dom(text: &str) -> Option<String> {
+    let doc = Document::parse(text).ok()?;
+    let appmsg = doc.descendants().find(|node| node.has_tag_name("appmsg"))?;
+    let title = xml_text(xml_child(appmsg, "title")).unwrap_or_default();
+    let atype = xml_text(xml_child(appmsg, "type")).unwrap_or_default();
+    match atype.as_str() {
+        "6" => Some(format_file_appmsg(appmsg, &title)),
+        "19" => Some(format_record_appmsg(appmsg, &title)),
+        _ => None,
+    }
+}
+
+fn parse_appmsg_legacy(text: &str) -> Option<String> {
     let title = extract_xml_text(text, "title")?;
     let atype = extract_xml_text(text, "type").unwrap_or_default();
     match atype.as_str() {
@@ -1221,6 +1238,119 @@ fn parse_appmsg(text: &str) -> Option<String> {
         }
         "33" | "36" | "44" => Some(if !title.is_empty() { format!("[小程序] {}", title) } else { "[小程序]".into() }),
         _ => Some(if !title.is_empty() { format!("[链接] {}", title) } else { "[链接/文件]".into() }),
+    }
+}
+
+fn format_file_appmsg<'a, 'input>(appmsg: Node<'a, 'input>, title: &str) -> String {
+    let mut meta = Vec::new();
+    if let Some(size) = xml_child(appmsg, "appattach")
+        .and_then(|attach| xml_text(xml_child(attach, "totallen")))
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|size| *size > 0)
+    {
+        meta.push(format_byte_size(size));
+    }
+    if let Some(ext) = xml_child(appmsg, "appattach")
+        .and_then(|attach| xml_text(xml_child(attach, "fileext")))
+        .filter(|ext| !ext.is_empty())
+    {
+        meta.push(ext);
+    }
+
+    let base = if !title.is_empty() {
+        format!("[文件] {}", title)
+    } else {
+        "[文件]".into()
+    };
+    if meta.is_empty() {
+        base
+    } else {
+        format!("{} ({})", base, meta.join(", "))
+    }
+}
+
+fn format_record_appmsg<'a, 'input>(appmsg: Node<'a, 'input>, title: &str) -> String {
+    let items = record_item_lines(appmsg);
+    let mut header = if !title.is_empty() {
+        format!("[合并聊天记录] {}", title)
+    } else {
+        "[合并聊天记录]".into()
+    };
+    if !items.is_empty() {
+        header.push_str(&format!(" ({}条)", items.len()));
+    }
+
+    let mut lines = vec![header];
+    if items.is_empty() {
+        if let Some(desc) = xml_text(xml_child(appmsg, "des")).filter(|desc| !desc.is_empty()) {
+            lines.push(format!("  {}", collapse_text(&desc, 120)));
+        }
+    } else {
+        for item in items.iter().take(10) {
+            lines.push(format!("  - {}", item));
+        }
+        if items.len() > 10 {
+            lines.push(format!("  - ... 还有{}条", items.len() - 10));
+        }
+    }
+    lines.join("\n")
+}
+
+fn record_item_lines<'a, 'input>(appmsg: Node<'a, 'input>) -> Vec<String> {
+    let mut lines = record_item_lines_from_node(appmsg);
+    if !lines.is_empty() {
+        return lines;
+    }
+
+    let Some(record_xml) = xml_text(xml_child(appmsg, "recorditem")).filter(|value| !value.is_empty()) else {
+        return Vec::new();
+    };
+    let unescaped = unescape_html(&record_xml);
+    for candidate in [&record_xml, &unescaped] {
+        if let Ok(doc) = Document::parse(candidate) {
+            lines = record_item_lines_from_node(doc.root_element());
+            if !lines.is_empty() {
+                break;
+            }
+        }
+    }
+    lines
+}
+
+fn record_item_lines_from_node<'a, 'input>(node: Node<'a, 'input>) -> Vec<String> {
+    node.descendants()
+        .filter(|child| child.has_tag_name("dataitem"))
+        .filter_map(format_record_item)
+        .collect()
+}
+
+fn format_record_item<'a, 'input>(item: Node<'a, 'input>) -> Option<String> {
+    let name = first_child_text(item, &["sourcename", "datasrcname", "sourceusername"]);
+    let desc = first_child_text(item, &["datadesc", "datatitle", "datafmt"])
+        .or_else(|| item.attribute("datatype").and_then(record_datatype_label).map(str::to_string))?;
+    let desc = collapse_text(&desc, 100);
+    if let Some(name) = name.filter(|value| !value.is_empty()) {
+        Some(format!("{}: {}", name, desc))
+    } else {
+        Some(desc)
+    }
+}
+
+fn first_child_text<'a, 'input>(node: Node<'a, 'input>, tags: &[&str]) -> Option<String> {
+    tags.iter()
+        .find_map(|tag| xml_text(xml_child(node, tag)))
+        .filter(|value| !value.is_empty())
+}
+
+fn record_datatype_label(datatype: &str) -> Option<&'static str> {
+    match datatype {
+        "1" => Some("[文本]"),
+        "2" => Some("[图片]"),
+        "3" => Some("[语音]"),
+        "4" => Some("[视频]"),
+        "6" => Some("[文件]"),
+        "17" => Some("[链接]"),
+        _ => None,
     }
 }
 
@@ -1272,6 +1402,30 @@ fn collapse_text(text: &str, max_chars: usize) -> String {
     } else {
         collapsed
     }
+}
+
+fn format_byte_size(bytes: u64) -> String {
+    const KB: f64 = 1024.0;
+    const MB: f64 = KB * 1024.0;
+    const GB: f64 = MB * 1024.0;
+    let bytes_f = bytes as f64;
+    if bytes_f >= GB {
+        format_decimal_unit(bytes_f / GB, "GB")
+    } else if bytes_f >= MB {
+        format_decimal_unit(bytes_f / MB, "MB")
+    } else if bytes_f >= KB {
+        format_decimal_unit(bytes_f / KB, "KB")
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
+fn format_decimal_unit(value: f64, unit: &str) -> String {
+    let mut s = format!("{:.1}", value);
+    if s.ends_with(".0") {
+        s.truncate(s.len() - 2);
+    }
+    format!("{} {}", s, unit)
 }
 
 fn extract_xml_text(xml: &str, tag: &str) -> Option<String> {
@@ -1340,6 +1494,48 @@ fn unescape_html(s: &str) -> String {
 #[cfg(test)]
 mod appmsg_tests {
     use super::*;
+
+    #[test]
+    fn parse_forwarded_chat_record_expands_record_items() {
+        let xml = r#"
+<msg>
+  <appmsg appid="" sdkver="0">
+    <title>群聊的聊天记录</title>
+    <des>张三: 早上好
+李四: 收到</des>
+    <type>19</type>
+    <recorditem>&lt;recordinfo&gt;&lt;datalist count="2"&gt;&lt;dataitem datatype="1"&gt;&lt;sourcename&gt;张三&lt;/sourcename&gt;&lt;sourcetime&gt;1710000000&lt;/sourcetime&gt;&lt;datadesc&gt;早上好 &amp;amp; coffee&lt;/datadesc&gt;&lt;/dataitem&gt;&lt;dataitem datatype="2"&gt;&lt;sourcename&gt;李四&lt;/sourcename&gt;&lt;sourcetime&gt;1710000060&lt;/sourcetime&gt;&lt;datafmt&gt;图片&lt;/datafmt&gt;&lt;datadesc&gt;[图片]&lt;/datadesc&gt;&lt;/dataitem&gt;&lt;/datalist&gt;&lt;/recordinfo&gt;</recorditem>
+  </appmsg>
+</msg>
+        "#;
+
+        assert_eq!(
+            parse_appmsg(xml).as_deref(),
+            Some("[合并聊天记录] 群聊的聊天记录 (2条)\n  - 张三: 早上好 & coffee\n  - 李四: [图片]")
+        );
+    }
+
+    #[test]
+    fn parse_file_appmsg_includes_attachment_metadata() {
+        let xml = r#"
+<msg>
+  <appmsg appid="" sdkver="0">
+    <title>report.pdf</title>
+    <type>6</type>
+    <appattach>
+      <totallen>1536</totallen>
+      <fileext>pdf</fileext>
+    </appattach>
+    <md5>abcdef123456</md5>
+  </appmsg>
+</msg>
+        "#;
+
+        assert_eq!(
+            parse_appmsg(xml).as_deref(),
+            Some("[文件] report.pdf (1.5 KB, pdf)")
+        );
+    }
 
     #[test]
     fn parse_quote_appmsg_reads_refermsg_content() {


### PR DESCRIPTION
Related to #22。

## 背景

当前 `wx history` / `wx search` 对 WeChat `appmsg`（`base type = 49`）的处理比较粗：

- `type=19` 的合并聊天记录会退化成普通链接标题
- `type=6` 的文件消息只显示标题，缺少文件大小 / 扩展名等信息
- `--type link|file` 的 SQL 过滤直接比较 `local_type = 49`，会漏掉大量 WeChat 4.x 的真实 `appmsg` 行，因为这类消息经常把 subtype 编进高 32 位，例如 `19<<32 | 49`、`57<<32 | 49`

实际本地数据里，这会直接影响历史查询、搜索结果，以及对刚发送消息的验证体验。例如最新发到文件传输助手的合并聊天记录，在旧逻辑里会显示成 `[链接] ...`。

## 改动

- 在 `src/daemon/query.rs` 中把 `appmsg` 解析改成 DOM-first：
  - `type=19`：解析 `recorditem` 里的 CDATA / 内嵌 XML，输出合并聊天记录摘要
  - `type=6`：解析 `appattach`，补充文件大小 / 扩展名 / md5
  - `type=57`：保留引用消息解析，并复用新的递归逻辑
- `history` / `search` 的 `--type` 过滤改为按低 32 位 base type 比较，避免 `19<<32 | 49` / `57<<32 | 49` 这类消息被漏掉
- 新增回归测试：
  - 合并聊天记录样例解析
  - 文件消息元信息解析
  - `query_messages` 对高位 subtype 的过滤行为
- 新增本地 `#[ignore]` 真实数据 probe，方便后续在开发机上继续回归验证
- 把这次确认下来的 WeChat 4.x `appmsg` 解析坑和本地验证坑补充到 `CLAUDE.md`

## 兼容性

- 非 `appmsg` 消息行为不变
- `type` 字段仍保持现有语义，表示底层 base type；本 PR 主要改善 `content` 的可读性和 `--type` 的过滤正确性
- `appmsg` 解析仍保留 legacy string fallback，避免坏 XML 直接把整条消息打空
- 不新增依赖，继续复用现有的 `roxmltree`

## 验证

项目级验证：

```bash
cargo check
cargo test appmsg_tests -- --nocapture
```

本地真实数据验证（ignored tests，使用 `~/.wx-cli/cache`，不把真实消息内容写入仓库）：

```bash
cargo test local_real_appmsg_probe -- --ignored --nocapture
cargo test local_latest_filehelper_base49_probe -- --ignored --nocapture
cargo test local_latest_filehelper_merged_record_probe -- --ignored --nocapture
```

结果：

- 本地缓存中扫到 `27036` 条 base-49 `appmsg`，解析成功 `26784` 条
- 其中包含 `1370` 条 `type=6` 文件消息、`558` 条 `type=19` 合并聊天记录、`6517` 条 `type=57` 引用消息
- 文件传输助手里最新一条合并聊天记录（`19<<32 | 49`）已能正确解析成多条聊天摘要，不再显示成普通链接标题

未跑完整 cross-target check：当前 macOS 本机缺 Linux / Windows 对应 C 交叉工具链，`zstd-sys` / `libsqlite3-sys` 会在工具链层面失败。本 PR 没有新增平台分支或 C 依赖。