### PR TITLE
docs(macOS): 补充 WeChat 重签名后的录屏权限排障

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ sudo wx init
 > codesign --remove-signature "/Applications/WeChat.app/Contents/Frameworks/vlc_plugins/librtp_mpeg4_plugin.dylib"
 > codesign --force --deep --sign - /Applications/WeChat.app
 > ```
+>
+> 重签名后，macOS 的部分隐私权限会按新的 code signature 重新校验。如果微信截图提示需要开启录屏权限，即使系统设置里看起来已经允许，也需要重新添加微信到 **Screen Recording / 录屏与系统录音**。见 [macOS 权限与签名指南](docs/macos-permission-guide.md#五重签名后微信截图提示开启录屏权限)。
 
 **Linux**
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -65,6 +65,16 @@ codesign --remove-signature "/Applications/WeChat.app/Contents/Frameworks/vlc_pl
 codesign --force --deep --sign - /Applications/WeChat.app
 ```
 
+重签名会改变 WeChat.app 的 code signature。若微信截图提示需要开启录屏权限，即使系统设置里看起来已经允许，也要重新生成 Screen Recording / 录屏与系统录音授权：
+
+```bash
+tccutil reset ScreenCapture com.tencent.xinWeChat
+killall tccd 2>/dev/null || true
+open "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+```
+
+然后在 **隐私与安全性 → 录屏与系统录音** 的上半区添加 `/Applications/WeChat.app` 并开启；在 macOS 26 上，下半区 **仅系统录音** 不足以修复微信截图。
+
 **第二步：重启 WeChat**
 
 ```bash

--- a/docs/macos-permission-guide.md
+++ b/docs/macos-permission-guide.md
@@ -196,3 +196,73 @@ open /Applications/WeChat.app
 | "SIP 阻止了调试微信" | ❌ SIP 只保护系统进程，微信不受 SIP 保护 |
 | "加了 sshd 到 FDA 就行" | ❌ 还需要加 `sshd-keygen-wrapper`，且要重连 SSH |
 | "微信开着也能重签名" | ❌ 运行中的 binary/dylib 被占用，codesign 会失败 |
+
+---
+
+## 五、重签名后微信截图提示开启录屏权限
+
+### 现象
+
+完成 ad-hoc 重签名和 `wx init` 后，微信自带截图功能可能提示需要开启录屏权限；但系统设置里看起来已经允许了微信。
+
+常见触发条件：
+
+- macOS 上执行过 `codesign --force --deep --sign - /Applications/WeChat.app`
+- 微信随后重新启动并登录
+- 使用微信截图时提示缺少录屏权限
+
+### 原因
+
+macOS 的 TCC 隐私权限不只按 bundle id 识别应用，也会保存应用的 code requirement / code signature 信息。微信从官方签名变成 ad-hoc 签名后，旧的 Screen Recording 授权记录可能不再匹配当前的 WeChat.app。
+
+这时系统设置里可能仍能看到“微信.app”开关，但实际截图权限已经失效，需要按当前签名重新生成授权记录。
+
+### 修复步骤
+
+先重置微信的 Screen Recording 授权：
+
+```bash
+tccutil reset ScreenCapture com.tencent.xinWeChat
+killall tccd 2>/dev/null || true
+open "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+```
+
+然后在 GUI 中重新添加微信：
+
+1. 打开 **隐私与安全性 → 录屏与系统录音**。
+2. 在上半区 **录屏与系统录音** 点击 `+`。
+3. 选择 `/Applications/WeChat.app`。
+4. 确认开关为开启。
+5. 选择“退出并重新打开”，或手动退出并重新打开微信。
+
+注意：在 macOS 26 上，相关设置可能显示为两块：
+
+| 区域 | 作用 |
+|------|------|
+| **录屏与系统录音** | 允许应用录制屏幕内容和系统音频；微信截图需要这一项 |
+| **仅系统录音** | 只允许录制系统音频；只打开这一项不能修复微信截图 |
+
+### 验证
+
+检查当前 WeChat.app 是否已被 ad-hoc 签名：
+
+```bash
+codesign -dv --verbose=4 /Applications/WeChat.app 2>&1 | grep -E "Signature|flags|TeamIdentifier"
+```
+
+期望能看到类似：
+
+```text
+flags=0x2(adhoc)
+Signature=adhoc
+TeamIdentifier=not set
+```
+
+检查系统 TCC 记录中是否已有微信的 Screen Recording 授权：
+
+```bash
+sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" \
+  "select service,client,auth_value,length(csreq) from access where service='kTCCServiceScreenCapture' and client='com.tencent.xinWeChat';"
+```
+
+其中 `auth_value=2` 表示允许。`csreq` 长度有值表示系统已为当前应用身份保存 code requirement。


### PR DESCRIPTION
## 背景

macOS 上按 README 流程对 `/Applications/WeChat.app` 做 ad-hoc 重签名并运行 `wx init` 后，WeChat.app 的 code signature 会变化。此时 TCC 里已有的 Screen Recording 授权可能仍在系统设置中显示为已开启，但实际不再匹配当前的 WeChat.app，导致微信自带截图提示需要开启录屏权限。

## 这次改动

- 在 README 的 macOS 初始化步骤后增加短提示，并链接到详细权限指南。
- 在 `docs/macos-permission-guide.md` 增加「重签名后微信截图提示开启录屏权限」排障章节。
- 同步更新 `SKILL.md`，让 agent 在安装/初始化 wx-cli 时也能提示这个 macOS TCC 场景。

## 实测环境

- macOS: 26.4.1
- WeChat: 4.1.9
- wx-cli: 0.1.10
- 现象：微信截图提示需要开启录屏权限；系统设置中微信只在「仅系统录音」区域开启。
- 修复：`tccutil reset ScreenCapture com.tencent.xinWeChat` 后，在「录屏与系统录音」上半区重新添加 `/Applications/WeChat.app`，退出并重新打开微信。

## 验证

- `git diff --check`
- 文档改动，未运行 `cargo check`
