### PR TITLE
fix(init): show config.json path in auto-detect error

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -35,8 +35,13 @@ pub fn cmd_init(force: bool) -> Result<()> {
 
     // Step 1: 检测 db_dir
     println!("检测微信数据目录...");
-    let db_dir = config::auto_detect_db_dir()
-        .context("未能自动检测到微信数据目录\n请手动编辑 config.json 中的 db_dir 字段")?;
+    let db_dir = config::auto_detect_db_dir().with_context(|| format!(
+        "未能自动检测到微信数据目录\n\
+         请编辑配置文件并填写 db_dir 字段:\n  \
+         {}\n\
+         （文件不存在则首次保存后自动创建；db_dir 示例: <data_root>\\xwechat_files\\<wxid>\\db_storage）",
+        config_path.display()
+    ))?;
     println!("找到数据目录: {}", db_dir.display());
 
     // Step 2: 扫描密钥（需要 root/sudo）


### PR DESCRIPTION
## Problem

When `wx init` cannot auto-detect the Weixin data directory, it prints:

```
错误: 未能自动检测到微信数据目录
请手动编辑 config.json 中的 db_dir 字段
```

…without saying **where** that `config.json` lives. On Windows that is `%USERPROFILE%\.wx-cli\config.json`, which is non-obvious — users have to grep the binary or read the source to find it.

## Fix

`cmd_init()` already computes `config_path` at the top of the function. This patch just feeds it into the error context, plus adds a concrete example of the `db_dir` shape so users know what to put there.

After:

```
错误: 未能自动检测到微信数据目录
请编辑配置文件并填写 db_dir 字段:
  C:\Users\<you>\.wx-cli\config.json
（文件不存在则首次保存后自动创建；db_dir 示例: <data_root>\xwechat_files\<wxid>\db_storage）
```

## Notes

- One-file change, no behaviour shift beyond the error string.
- Paired PR: #63 (resolves the `MyDocument:` token in `*.ini` so auto-detect actually succeeds for users with relocated Documents — which is the case that hit this error in the first place).