### PR TITLE
docs(macos): document codesign side-effect popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ sudo wx init
 >
 > 重签名后 macOS 的 TCC 隐私授权按新 code signature 重新校验，旧记录会失效。如果跳过 `tccutil reset`，微信截图/视频通话/麦克风等权限可能"看起来已开启但实际拒绝"。详见 [macOS 权限与签名指南](docs/macos-permission-guide.md#五重签名后微信权限-silent-失效)。
 
-> **副作用提示**：完成上面的 ad-hoc 重签后，macOS 会比较频繁地弹 `"微信" 想访问其他 App 的数据`（在微信里打开公众号文章时尤其容易触发）。这是当前 macOS invasive init 路径的已知副作用：重签后 WeChat 的 code identity 变了，它再访问自己原来的 container / 缓存数据会被系统识别为"跨 App 访问"。点"允许"通常只是放行当前 WeChat 进程；想彻底不弹得恢复官方 WeChat（代价是这条 macOS memory-scan init 会失效）。详见 [macOS 权限与签名指南 §六](docs/macos-permission-guide.md#六微信-想访问其他-app-的数据-弹窗)。
+> **副作用提示**：完成上面的 ad-hoc 重签后，macOS 会比较频繁地弹 `"微信" 想访问其他 App 的数据`（在微信里打开公众号文章时尤其容易触发）。这是当前 macOS invasive init 路径的已知副作用：重签后 WeChat 的 code identity 变了，它再访问自己原来的 container / 缓存数据会被系统识别为"跨 App 访问"。点"允许"通常只是放行当前 WeChat 进程；想彻底不弹得恢复官方 WeChat——这只放弃**当前依赖重签的默认路径**，**不等于放弃 memory-scan**：在本机 GUI Terminal 下、Terminal.app 拿到「开发者工具」TCC 授权后，对 Apple 官方签名的 WeChat 仍可以走通；只有 SSH 远程 + Apple 签名 WeChat 这种组合才必须重签。详见 [macOS 权限与签名指南 §六](docs/macos-permission-guide.md#六微信-想访问其他-app-的数据-弹窗)。
 
 **Linux**
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ sudo wx init
 >
 > 重签名后 macOS 的 TCC 隐私授权按新 code signature 重新校验，旧记录会失效。如果跳过 `tccutil reset`，微信截图/视频通话/麦克风等权限可能"看起来已开启但实际拒绝"。详见 [macOS 权限与签名指南](docs/macos-permission-guide.md#五重签名后微信权限-silent-失效)。
 
+> **副作用提示**：完成上面的 ad-hoc 重签后，macOS 会比较频繁地弹 `"微信" 想访问其他 App 的数据`（在微信里打开公众号文章时尤其容易触发）。这是当前 macOS invasive init 路径的已知副作用：重签后 WeChat 的 code identity 变了，它再访问自己原来的 container / 缓存数据会被系统识别为"跨 App 访问"。点"允许"通常只是放行当前 WeChat 进程；想彻底不弹得恢复官方 WeChat（代价是这条 macOS memory-scan init 会失效）。详见 [macOS 权限与签名指南 §六](docs/macos-permission-guide.md#六微信-想访问其他-app-的数据-弹窗)。
+
 **Linux**
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ sudo wx init
 >
 > 重签名后 macOS 的 TCC 隐私授权按新 code signature 重新校验，旧记录会失效。如果跳过 `tccutil reset`，微信截图/视频通话/麦克风等权限可能"看起来已开启但实际拒绝"。详见 [macOS 权限与签名指南](docs/macos-permission-guide.md#五重签名后微信权限-silent-失效)。
 
-> **副作用提示**：完成上面的 ad-hoc 重签后，macOS 会比较频繁地弹 `"微信" 想访问其他 App 的数据`（在微信里打开公众号文章时尤其容易触发）。这是当前 macOS invasive init 路径的已知副作用：重签后 WeChat 的 code identity 变了，它再访问自己原来的 container / 缓存数据会被系统识别为"跨 App 访问"。点"允许"通常只是放行当前 WeChat 进程；想彻底不弹得恢复官方 WeChat——这只放弃**当前依赖重签的默认路径**，**不等于放弃 memory-scan**：在本机 GUI Terminal 下、Terminal.app 拿到「开发者工具」TCC 授权后，对 Apple 官方签名的 WeChat 仍可以走通；只有 SSH 远程 + Apple 签名 WeChat 这种组合才必须重签。详见 [macOS 权限与签名指南 §六](docs/macos-permission-guide.md#六微信-想访问其他-app-的数据-弹窗)。
+> **副作用提示**：完成上面的 ad-hoc 重签后，macOS 会比较频繁地弹 `"微信" 想访问其他 App 的数据`（在微信里打开公众号文章时尤其容易触发）。这是当前 macOS invasive init 路径的已知副作用：重签后 WeChat 的 code identity 变了，它再访问自己原来的 container / 缓存数据会被系统识别为"跨 App 访问"。点"允许"通常只是放行当前 WeChat 进程；想彻底不弹得恢复官方 WeChat——这只放弃**当前依赖重签的默认路径**，**不等于放弃 memory-scan**：在本机 GUI Terminal 下、Terminal.app 拿到「开发者工具」TCC 授权后，对 Apple 官方签名的 WeChat 应当仍可以走通（实证覆盖只有 Catalina / Big Sur，macOS 14+ 未在本项目内实测）；只有 SSH 远程 + Apple 签名 WeChat 这种组合才必须重签。详见 [macOS 权限与签名指南 §六](docs/macos-permission-guide.md#六微信-想访问其他-app-的数据-弹窗)。
 
 **Linux**
 

--- a/docs/macos-permission-guide.md
+++ b/docs/macos-permission-guide.md
@@ -313,7 +313,8 @@ codesign --force --deep --sign - /Applications/WeChat.app
 
 彻底不弹：
 - 把 `/Applications/WeChat.app` 恢复成官方签名（重装官方 WeChat 包），不再执行 `codesign --force --deep --sign -`
-- 这一步只是放弃**当前依赖 ad-hoc 重签的默认路径**，并不等于放弃 macOS memory-scan：在本机 GUI Terminal 下、对 Terminal.app 授予「开发者工具」TCC 权限后，`task_for_pid` 对 Apple 官方签名（hardened runtime）的 WeChat 仍能走通——参考 §一 实测表里的"Apple 签名 + 本机 Terminal sudo = ✅"
+- 这一步只是放弃**当前依赖 ad-hoc 重签的默认路径**，并不等于放弃 macOS memory-scan：在本机 GUI Terminal 下、对 Terminal.app 授予「开发者工具」TCC 权限后，`task_for_pid` 对 Apple 官方签名（hardened runtime）的 WeChat 应当仍能走通——参考 §一 实测表里的"Apple 签名 + 本机 Terminal sudo = ✅"
+- ⚠️ 实测覆盖范围说明：§一 实测表里 "Apple 签名 + 本机 Terminal sudo ✅" 的两条实证只覆盖 macOS 10.15 (Catalina) 与 11.1 (Big Sur)；macOS 14 (Sonoma) / 15 (Sequoia) 上是否仍走通**未在本项目内实测**。如果你按这条路恢复官方签名后发现 init 走不通，请回到重签路径并接受本节描述的弹窗副作用
 - 真正受限的场景是 SSH 远程 + Apple 签名 WeChat：`sshd` 拿不到 TCC 开发者工具授权，这时才必须走重签路径
 
 长期方向：

--- a/docs/macos-permission-guide.md
+++ b/docs/macos-permission-guide.md
@@ -272,3 +272,49 @@ TeamIdentifier=not set
 ```
 
 最直接的功能验证：在微信里使用截图、视频通话、麦克风等功能，按 GUI 弹窗的"允许"重新授权一次，之后正常工作。
+
+---
+
+## 六、`"微信" 想访问其他 App 的数据` 弹窗
+
+### 现象
+
+执行过 `wx init`、对 `/Applications/WeChat.app` 做过 ad-hoc 重签名之后，再使用微信时会比较频繁地看到 macOS 弹出：
+
+```
+"微信" 想访问其他 App 的数据。
+单独存放 App 数据可让你更容易管理隐私和安全。
+[ 不允许 ]   [ 允许 ]
+```
+
+最常见的触发面是**在微信里打开公众号文章**，但这只是高频触发面，不是根因。
+
+### 根因（第一性原理）
+
+这弹窗是 macOS Ventura+ / 14 / 15 对 **app data container 跨身份访问** 的保护：当前进程（"微信"）正在读取另一个 code identity 的 app 留下的数据。
+
+我们当前 macOS 方案为了让 `task_for_pid` 能拿到 WeChat 的 task port、读取进程内存里的 raw key，要求用户执行：
+
+```bash
+codesign --force --deep --sign - /Applications/WeChat.app
+```
+
+这一步把 WeChat 从 Apple 官方签名换成 ad-hoc 身份。对用户来说它仍然是"微信"；对 macOS 安全模型来说，**重签前的 WeChat** 和 **重签后的 WeChat** 已经不是同一个 app identity。
+
+之后当（重签后的）微信访问它原本的 `~/Library/Containers/com.tencent.xinWeChat/...`、缓存、app group 等数据时，系统看到的是"一个新身份在读旧身份留下的 container 数据"，于是按隐私保护策略弹这个对话框。公众号文章里的 webview / cookie / 缓存路径刚好踩到了这条访问路径，所以"打开公众号就弹"会非常容易复现，但**本质不是公众号页面的问题**，而是 code identity + container access。
+
+> 注意：这**不是** "wx-cli 在偷偷读别的 App 的数据"，wx-cli 进程本身对 WeChat container 是只读访问；但**要求用户重签 WeChat** 这一步本身就是这类弹窗的直接诱因。所以这是当前 macOS invasive init 路径的已知副作用，不是与 wx-cli 无关的系统行为。
+
+### 应对
+
+短期缓解：
+- 点"允许"通常只是放行**当前这次** WeChat 进程；下一次 WeChat 启动权限会 reset，可能还会再弹
+- 该授权一般不会在 System Settings 里留下显式开关，因为它绑定的是动态的 code identity
+
+彻底不弹（代价是放弃 macOS memory-scan）：
+- 把 `/Applications/WeChat.app` 恢复成官方签名（重装官方 WeChat 包）
+- 不再执行 `codesign --force --deep --sign -`
+- 后果：`task_for_pid` 在 Apple 签名的 hardened runtime 下会失败，当前 macOS 这条「扫内存提取 raw key」的 init 路径就用不了
+
+长期方向：
+- 这条副作用的真正修复是改造 macOS 端 init，让它不再修改 `/Applications/WeChat.app`。在那之前，这是已知 trade-off。

--- a/docs/macos-permission-guide.md
+++ b/docs/macos-permission-guide.md
@@ -311,10 +311,10 @@ codesign --force --deep --sign - /Applications/WeChat.app
 - 点"允许"通常只是放行**当前这次** WeChat 进程；下一次 WeChat 启动权限会 reset，可能还会再弹
 - 该授权一般不会在 System Settings 里留下显式开关，因为它绑定的是动态的 code identity
 
-彻底不弹（代价是放弃 macOS memory-scan）：
-- 把 `/Applications/WeChat.app` 恢复成官方签名（重装官方 WeChat 包）
-- 不再执行 `codesign --force --deep --sign -`
-- 后果：`task_for_pid` 在 Apple 签名的 hardened runtime 下会失败，当前 macOS 这条「扫内存提取 raw key」的 init 路径就用不了
+彻底不弹：
+- 把 `/Applications/WeChat.app` 恢复成官方签名（重装官方 WeChat 包），不再执行 `codesign --force --deep --sign -`
+- 这一步只是放弃**当前依赖 ad-hoc 重签的默认路径**，并不等于放弃 macOS memory-scan：在本机 GUI Terminal 下、对 Terminal.app 授予「开发者工具」TCC 权限后，`task_for_pid` 对 Apple 官方签名（hardened runtime）的 WeChat 仍能走通——参考 §一 实测表里的"Apple 签名 + 本机 Terminal sudo = ✅"
+- 真正受限的场景是 SSH 远程 + Apple 签名 WeChat：`sshd` 拿不到 TCC 开发者工具授权，这时才必须走重签路径
 
 长期方向：
-- 这条副作用的真正修复是改造 macOS 端 init，让它不再修改 `/Applications/WeChat.app`。在那之前，这是已知 trade-off。
+- 这条副作用的真正修复是把 `wx init` 重新设计成 `safe → assisted → invasive fallback` 三层：默认不动 WeChat，只有在前两条都不可行时才走 ad-hoc 重签，并先打出完整副作用清单让用户显式确认。在那之前，这是已知 trade-off。

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -100,7 +100,7 @@ pub fn cmd_init(force: bool) -> Result<()> {
     #[cfg(target_os = "macos")]
     {
         eprintln!();
-        eprintln!("⚠️  macOS 副作用提示：");
+        eprintln!("[macOS] 副作用提示：");
         eprintln!("   如果你是通过对 /Applications/WeChat.app 做 ad-hoc 重签来让 init 走通的，");
         eprintln!("   之后 macOS 可能弹 \"微信\" 想访问其他 App 的数据（在微信里打开公众号文章");
         eprintln!("   时尤其常见）。这是 ad-hoc 重签后 WeChat 的 code identity 变了导致的，");

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -97,6 +97,16 @@ pub fn cmd_init(force: bool) -> Result<()> {
 
     println!("初始化完成，可以使用 wx sessions / wx history 等命令了");
 
+    #[cfg(target_os = "macos")]
+    {
+        eprintln!();
+        eprintln!("⚠️  macOS 副作用提示：");
+        eprintln!("   你刚才对 /Applications/WeChat.app 做过 ad-hoc 重签，之后 macOS 可能");
+        eprintln!("   弹 \"微信\" 想访问其他 App 的数据（在微信里打开公众号文章时尤其常见）。");
+        eprintln!("   这是当前 macOS invasive init 路径的已知副作用，不是 wx-cli 在读其他 App 数据。");
+        eprintln!("   详见 docs/macos-permission-guide.md 第六节。");
+    }
+
     Ok(())
 }
 

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -101,10 +101,13 @@ pub fn cmd_init(force: bool) -> Result<()> {
     {
         eprintln!();
         eprintln!("⚠️  macOS 副作用提示：");
-        eprintln!("   你刚才对 /Applications/WeChat.app 做过 ad-hoc 重签，之后 macOS 可能");
-        eprintln!("   弹 \"微信\" 想访问其他 App 的数据（在微信里打开公众号文章时尤其常见）。");
-        eprintln!("   这是当前 macOS invasive init 路径的已知副作用，不是 wx-cli 在读其他 App 数据。");
-        eprintln!("   详见 docs/macos-permission-guide.md 第六节。");
+        eprintln!("   如果你是通过对 /Applications/WeChat.app 做 ad-hoc 重签来让 init 走通的，");
+        eprintln!("   之后 macOS 可能弹 \"微信\" 想访问其他 App 的数据（在微信里打开公众号文章");
+        eprintln!("   时尤其常见）。这是 ad-hoc 重签后 WeChat 的 code identity 变了导致的，");
+        eprintln!("   不是 wx-cli 在读其他 App 数据。");
+        eprintln!("   完整说明：https://github.com/jackwener/wx-cli/blob/main/docs/macos-permission-guide.md#六微信-想访问其他-app-的数据-弹窗");
+        eprintln!("   （如果你的 WeChat 仍是 Apple 官方签名、init 是靠 GUI Terminal + 开发者工具");
+        eprintln!("    授权走通的，则不会出现这个弹窗，可以忽略本提示。）");
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Document the `"微信" 想访问其他 App 的数据` macOS popup that users hit after running `wx init` on macOS. This was reported by users (most reproducibly when opening 公众号 articles in WeChat).

Per discussion in #wechat:bd233866 / #wechat:4b749d80, the root cause is **not** "wx-cli is reading other apps' data" and **not** a 公众号 page issue:

- The current macOS init path requires `codesign --force --deep --sign - /Applications/WeChat.app` so `task_for_pid` can read WeChat's memory.
- Re-signing changes WeChat's **code identity** from macOS's perspective.
- When the re-signed WeChat then accesses its own original container / cache / app-group data (公众号 WebView / cookie / cache being a high-frequency trigger surface), macOS treats this as cross-identity container access and fires the privacy popup.
- 点 "允许" usually only allows the current WeChat process; next launch may pop again.
- Truly avoiding the popup means restoring the official WeChat (cost: this macOS memory-scan init path stops working).

## Scope (per agreed plan)

3 places, kept minimal:

- **`README.md` macOS init** — short "副作用提示" callout pointing to the guide
- **`docs/macos-permission-guide.md`** — new §六 with first-principles explanation, mitigation options, long-term direction
- **`src/cli/init.rs`** — print a short macOS-only warning at the end of `wx init` so users see it right when they finish the invasive setup

Wording explicitly avoids:
- "和 wx-cli 无关"
- "只是公众号页面的问题"

## Test plan

- [x] `cargo check` (macOS) passes
- [x] `cargo check --target x86_64-pc-windows-gnu` passes
- [ ] CI green (Linux / Windows builds)
- [x] Manual review of the 3 wording locations

cc @wx-cli-codex — review per scope agreed in #wechat:4b749d80.